### PR TITLE
Add Excel export for overall stock status

### DIFF
--- a/app/routes/tank_stock_routes.py
+++ b/app/routes/tank_stock_routes.py
@@ -1,5 +1,6 @@
 import math
 import io
+from datetime import datetime
 from flask import Blueprint, request, send_file
 from app import db
 from app.models.site import Site
@@ -318,12 +319,29 @@ def tanks_with_stock():
 @stock_bp.route("/overall-stock-status/export", methods=["GET"])
 def export_overall_stock_status():
     site_id = request.args.get("siteId", type=int)
-
     records = TankStockService.get_overall_stock_status(site_id)
+
     from openpyxl import Workbook
+    from openpyxl.styles import Font
+
     wb = Workbook()
     ws = wb.active
     ws.title = "OverallStockStatus"
+
+    # Header section with metadata
+    title_cell = ws["A1"]
+    title_cell.value = "Overall Stock Status"
+    title_cell.font = Font(bold=True)
+    ws.merge_cells("A1:G1")
+    ws["A2"] = f"Generated: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}"
+
+    site_label = "All Sites"
+    if site_id:
+        site_name = db.session.query(Site.site_name).filter_by(site_id=site_id).scalar()
+        site_label = site_name or f"Site {site_id}"
+    ws["A3"] = f"Site: {site_label}"
+
+    ws.append([])  # blank row before table headers
     ws.append([
         "SiteName",
         "TankCode",
@@ -334,6 +352,11 @@ def export_overall_stock_status():
         "LastUpdated",
     ])
 
+    for cell in ws[ws.max_row]:
+        cell.font = Font(bold=True)
+
+    prev_site = None
+    prev_tank = None
     for (
         site_name,
         tank_code,
@@ -343,15 +366,17 @@ def export_overall_stock_status():
         quantity,
         last_updated,
     ) in records:
+        show_group = not (site_name == prev_site and tank_code == prev_tank)
         ws.append([
-            site_name,
-            tank_code,
-            tank_name,
+            site_name if show_group else "",
+            tank_code if show_group else "",
+            tank_name if show_group else "",
             type_code,
             common_name,
             quantity,
-            last_updated.isoformat() if last_updated else None,
+            last_updated.strftime("%Y-%m-%d %H:%M:%S") if last_updated else None,
         ])
+        prev_site, prev_tank = site_name, tank_code
 
     stream = io.BytesIO()
     wb.save(stream)

--- a/app/routes/tank_stock_routes.py
+++ b/app/routes/tank_stock_routes.py
@@ -1,6 +1,6 @@
 import math
 import io
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from flask import Blueprint, request, send_file
 from app import db
 from app.models.site import Site
@@ -331,9 +331,11 @@ def export_overall_stock_status():
     # Header section with metadata
     title_cell = ws["A1"]
     title_cell.value = "Overall Stock Status"
-    title_cell.font = Font(bold=True)
+    title_cell.font = Font(bold=True, size=16)
     ws.merge_cells("A1:G1")
-    ws["A2"] = f"Generated: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}"
+
+    generated_time = datetime.now(timezone(timedelta(hours=8))).strftime('%Y-%m-%d %H:%M:%S GMT+8')
+    ws["A2"] = f"Generated: {generated_time}"
 
     site_label = "All Sites"
     if site_id:
@@ -377,6 +379,15 @@ def export_overall_stock_status():
             last_updated.strftime("%Y-%m-%d %H:%M:%S") if last_updated else None,
         ])
         prev_site, prev_tank = site_name, tank_code
+
+    # Expand columns to fit content
+    for column_cells in ws.columns:
+        max_length = 0
+        column_letter = column_cells[0].column_letter
+        for cell in column_cells:
+            if cell.value:
+                max_length = max(max_length, len(str(cell.value)))
+        ws.column_dimensions[column_letter].width = max_length + 2
 
     stream = io.BytesIO()
     wb.save(stream)

--- a/app/routes/tank_stock_routes.py
+++ b/app/routes/tank_stock_routes.py
@@ -381,9 +381,11 @@ def export_overall_stock_status():
         prev_site, prev_tank = site_name, tank_code
 
     # Expand columns to fit content
-    for column_cells in ws.columns:
+    from openpyxl.utils import get_column_letter
+
+    for idx, column_cells in enumerate(ws.columns, 1):
         max_length = 0
-        column_letter = column_cells[0].column_letter
+        column_letter = get_column_letter(idx)
         for cell in column_cells:
             if cell.value:
                 max_length = max(max_length, len(str(cell.value)))

--- a/app/routes/tank_stock_routes.py
+++ b/app/routes/tank_stock_routes.py
@@ -1,5 +1,6 @@
 import math
-from flask import Blueprint, request
+import io
+from flask import Blueprint, request, send_file
 from app import db
 from app.models.site import Site
 from app.services.tank_stock_service import TankStockService
@@ -312,3 +313,53 @@ def tanks_with_stock():
     tank_stock_data = TankStockService.get_tanks_with_stock(site_id)
 
     return api_response("Tanks With Stock", data=tank_stock_data)
+
+
+@stock_bp.route("/overall-stock-status/export", methods=["GET"])
+def export_overall_stock_status():
+    site_id = request.args.get("siteId", type=int)
+
+    records = TankStockService.get_overall_stock_status(site_id)
+    from openpyxl import Workbook
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "OverallStockStatus"
+    ws.append([
+        "SiteName",
+        "TankCode",
+        "TankName",
+        "FishTypeCode",
+        "FishTypeName",
+        "Quantity",
+        "LastUpdated",
+    ])
+
+    for (
+        site_name,
+        tank_code,
+        tank_name,
+        type_code,
+        common_name,
+        quantity,
+        last_updated,
+    ) in records:
+        ws.append([
+            site_name,
+            tank_code,
+            tank_name,
+            type_code,
+            common_name,
+            quantity,
+            last_updated.isoformat() if last_updated else None,
+        ])
+
+    stream = io.BytesIO()
+    wb.save(stream)
+    stream.seek(0)
+
+    return send_file(
+        stream,
+        as_attachment=True,
+        download_name="overall_stock_status.xlsx",
+        mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )

--- a/app/services/tank_stock_service.py
+++ b/app/services/tank_stock_service.py
@@ -1,5 +1,5 @@
 from app import db
-from app.models import TankStock, Tank, StockTake, StockTakeItem, FishType
+from app.models import TankStock, Tank, StockTake, StockTakeItem, FishType, Site
 from sqlalchemy.orm import joinedload
 from app.utils import paginate_response
 from sqlalchemy import or_, cast, String, desc
@@ -432,3 +432,26 @@ class TankStockService:
             "utilizationPercent": round(utilization, 1),
             "capacityUtilizationPercent": round(capacity_utilization, 1)
         }
+
+    @staticmethod
+    def get_overall_stock_status(site_id: int | None = None):
+        query = (
+            db.session.query(
+                Site.site_name,
+                Tank.tank_code,
+                Tank.tank_name,
+                FishType.type_code,
+                FishType.common_name,
+                TankStock.quantity,
+                TankStock.last_updated,
+            )
+            .join(Tank, Tank.tank_id == TankStock.tank_id)
+            .join(Site, Site.site_id == Tank.site_id)
+            .join(FishType, FishType.type_id == TankStock.fish_type_id)
+            .order_by(Site.site_name, Tank.tank_name, FishType.common_name)
+        )
+
+        if site_id and site_id > 0:
+            query = query.filter(Tank.site_id == site_id)
+
+        return query.all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ Flask-Migrate
 Flask-Login
 python-dotenv
 gunicorn
+
+# Excel export
+openpyxl


### PR DESCRIPTION
## Summary
- add service query for overall stock status
- add endpoint to export tank stock to Excel
- include openpyxl dependency for spreadsheet support

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987dd78a14832e90c15153050e614b