### PR TITLE
Track tank health status with health check endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -73,3 +73,4 @@ def create_app():
     app.register_blueprint(public_qr_tank)
 
     return app
+

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,6 +6,6 @@ from .stock_adjustment import StockAdjustment
 from .tank_stock import TankStock
 from .stock_take import StockTake
 from .stock_take_item import StockTakeItem
-
 from .role import Role
 from .app_user import AppUser
+

--- a/app/models/tank.py
+++ b/app/models/tank.py
@@ -1,4 +1,3 @@
-import enum
 from datetime import datetime
 
 from app import db
@@ -25,6 +24,9 @@ class Tank(db.Model):
     deleted_by = db.Column(db.String(100))
     deleted_at = db.Column(db.DateTime)
     status = db.Column(db.String(20), default='Active')
+    last_health_check_at = db.Column(db.DateTime)
+    last_health_check_by = db.Column(db.String(100))
+    health_status = db.Column(db.String(20), default='healthy')
 
     # Relationships
     site = db.relationship("Site", back_populates="tanks")
@@ -46,9 +48,12 @@ class Tank(db.Model):
             'updatedAt': self.updated_at.isoformat() if self.updated_at else None,
             'deletedAt': self.deleted_at.isoformat() if self.deleted_at else None,
             'status': self.status,
+            'healthStatus': self.health_status,
             'createdBy': self.created_by,
             'updatedBy': self.updated_by,
-            'deletedBy': self.deleted_by
+            'deletedBy': self.deleted_by,
+            'lastHealthCheckAt': self.last_health_check_at.isoformat() if self.last_health_check_at else None,
+            'lastHealthCheckBy': self.last_health_check_by
         }
 
     def to_dict_QR_Purpose(self):

--- a/app/routes/tank_routes.py
+++ b/app/routes/tank_routes.py
@@ -116,3 +116,9 @@ def delete_tank(tank_id):
 def create_tank_batch():
     data = request.get_json()
     return TankService.batch_create(data, performed_by=get_performed_by())
+
+@tanks_bp.route('/<int:tank_id>/health-check', methods=['POST'])
+def record_tank_health_check(tank_id):
+    data = request.get_json() or {}
+    status = data.get('status')
+    return TankService.record_health_check(tank_id, status=status, performed_by=get_performed_by())

--- a/app/services/tank_service.py
+++ b/app/services/tank_service.py
@@ -60,6 +60,7 @@ class TankService:
             capacity=data.get('capacity'),
             size=data.get('size', 'medium').lower(),
             status=data.get('status', 'Active').capitalize(),
+            health_status=data.get('healthStatus', 'healthy').lower(),
             created_at=db.func.current_timestamp(),
             created_by=performed_by
         )
@@ -82,6 +83,8 @@ class TankService:
         tank.tank_name = data.get('tankName', tank.tank_name)
         tank.capacity = data.get('capacity', tank.capacity)
         tank.status = data.get('status', tank.status).capitalize()
+        if 'healthStatus' in data:
+            tank.health_status = data['healthStatus'].lower()
 
         if 'size' in data:
             tank.size = data['size'].lower()
@@ -90,6 +93,23 @@ class TankService:
         tank.updated_by = performed_by
         db.session.commit()
         return api_response("Tank updated successfully", data=tank.to_dict())
+
+    @staticmethod
+    def record_health_check(tank_id, status, performed_by=None):
+        tank = Tank.query.get(tank_id)
+        if not tank or tank.deleted_at:
+            return api_response("Tank not found", status_code=404)
+
+        if not status or status.lower() not in ['healthy', 'unhealthy']:
+            return api_response("Invalid health status", status_code=400)
+
+        tank.health_status = status.lower()
+        tank.last_health_check_at = db.func.current_timestamp()
+        tank.last_health_check_by = performed_by
+        tank.updated_at = db.func.current_timestamp()
+        tank.updated_by = performed_by
+        db.session.commit()
+        return api_response("Health check recorded", data=tank.to_dict())
 
     @staticmethod
     def delete(tank_id, performed_by=None):
@@ -185,6 +205,10 @@ class TankService:
                 errors['status'] = "Status is required"
             elif status.lower() not in ['active', 'maintenance', 'retired']:
                 errors['status'] = "Invalid status value"
+
+            health_status = data.get('healthStatus')
+            if health_status and health_status.lower() not in ['healthy', 'unhealthy']:
+                errors['healthStatus'] = "Invalid health status value"
 
         # Capacity validation (ensure it is a positive integer or zero)
         if 'capacity' in data:


### PR DESCRIPTION
## Summary
- add `health_status` field to Tank model
- allow setting health status via POST `/api/tanks/<tank_id>/health-check`
- validate and persist health status through TankService

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68989c6623dc832eb2f5e7700cfa03f5