### PR TITLE
fix: use correct content-type for image uploads

### DIFF
--- a/app/services/supa_images.py
+++ b/app/services/supa_images.py
@@ -1,5 +1,4 @@
 from uuid import uuid4
-from mimetypes import guess_extension
 from app.supabase_client import supabase, STORAGE_BUCKET
 
 
@@ -14,7 +13,7 @@ def upload_image(file_stream, content_type, folder_name, ext=".jpg"):
     res = supabase.storage.from_(STORAGE_BUCKET).upload(
         path,
         data,
-        {"content-type": ext, "cache-control": "31536000"},
+        {"content-type": content_type, "cache-control": "31536000"},
     )
     if getattr(res, "error", None):
         raise RuntimeError(f"Upload failed: {res.error}")


### PR DESCRIPTION
## Summary
- send correct MIME type when uploading images to Supabase storage
- clean up unused import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2aff37f44832eb8e9445364b5e7c9